### PR TITLE
Glow buffer fix on OpenGL. Caused by a wrong target size. (probably i…

### DIFF
--- a/Engine/source/renderInstance/renderTexTargetBinManager.cpp
+++ b/Engine/source/renderInstance/renderTexTargetBinManager.cpp
@@ -107,8 +107,7 @@ void RenderTexTargetBinManager::initPersistFields()
 
 bool RenderTexTargetBinManager::setTargetSize(const Point2I &newTargetSize)
 {
-   if( GFX->getAdapterType() != OpenGL && // Targets need to match up exactly in size on OpenGL.
-       mTargetSize.x >= newTargetSize.x &&
+   if( mTargetSize.x >= newTargetSize.x &&
        mTargetSize.y >= newTargetSize.y )
       return true;
 


### PR DESCRIPTION
…t was ok on the very old OpenGL 1.5 version)